### PR TITLE
Update nokogiri version in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
     foodcritic (4.0.0)
       erubis
       gherkin (~> 2.11)
-      nokogiri (~> 1.5)
+      nokogiri (~> 1.8.1)
       rake
       rufus-lru (~> 1.0)
       treetop (~> 1.4)


### PR DESCRIPTION
Addresses  the following e-mail we received from GitHub.

> 
>   | VividCortex/chef-cookbook
> 
> Known  critical severity security vulnerability detected in nokogiri < 1.8.1 defined in Gemfile.lock.                                                                                                                                                                                                                   Gemfile.lock update suggested: nokogiri ~> 1.8.1. | Known  critical severity security vulnerability detected in nokogiri < 1.8.1 defined in Gemfile.lock. | Gemfile.lock update suggested: nokogiri ~> 1.8.1. 
> Known  critical severity security vulnerability detected in nokogiri < 1.8.1 defined in Gemfile.lock.
> Gemfile.lock update suggested: nokogiri ~> 1.8.1.
>  
